### PR TITLE
ignore sendheaders command

### DIFF
--- a/lib/messages/index.js
+++ b/lib/messages/index.js
@@ -97,6 +97,7 @@ Messages.prototype._discardUntilNextMessage = function(dataBuffer) {
 };
 
 Messages.prototype._buildFromBuffer = function(command, payload) {
+  if (command === 'sendheaders') return; // BIP 130, ignore 'sendheaders' command
   if (!this.builder.commands[command]) {
     throw new Error('Unsupported message command: ' + command);
   }


### PR DESCRIPTION
This statement ignores the 'sendheaders' p2p command introduced in BIP130

context: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-September/011184.html
bitcoin commit: bitcoin/bitcoin#7129

everything I've read indicates this command is optional - would suggest that we simply ignore it in bitcore-p2p-dash.